### PR TITLE
Fix: Asegurar altura consistente en las tarjetas de demostración

### DIFF
--- a/src/components/InteractiveDemos.tsx
+++ b/src/components/InteractiveDemos.tsx
@@ -122,8 +122,8 @@ export function InteractiveDemos() {
                     ))}
                   </div>
                 </CardHeader>
-                <CardContent className="flex-1 flex flex-col">
-                  <ul className="list-disc list-inside space-y-2 mb-4">
+                <CardContent className="flex-1 flex flex-col h-64">
+                  <ul className="list-disc list-inside space-y-2 mb-4 overflow-y-auto">
                     {demo.features.map((feature, i) => (
                       <li key={i} className="text-sm text-muted-foreground">
                         {feature}


### PR DESCRIPTION
Modifiqué el componente InteractiveDemos para garantizar que todas las tarjetas de demostración tengan la misma altura.

Esto lo logré aplicando una altura fija al contenedor principal del contenido de la tarjeta (CardContent) y permitiendo el desplazamiento vertical (overflow-y-auto) para la lista de características si su contenido excede la altura asignada.

Este cambio soluciona el problema de alturas desiguales en las tarjetas, mejorando la consistencia visual de la sección de demostraciones.