### PR TITLE
Fix: Ensure uniform height for demo cards

### DIFF
--- a/src/components/InteractiveDemos.tsx
+++ b/src/components/InteractiveDemos.tsx
@@ -122,7 +122,7 @@ export function InteractiveDemos() {
                     ))}
                   </div>
                 </CardHeader>
-                <CardContent className="flex-1 flex flex-col h-64">
+                <CardContent className="flex-1 flex flex-col">
                   <ul className="list-disc list-inside space-y-2 mb-4 overflow-y-auto">
                     {demo.features.map((feature, i) => (
                       <li key={i} className="text-sm text-muted-foreground">


### PR DESCRIPTION
I removed the fixed height (`h-64`) from the `CardContent` component in `InteractiveDemos.tsx`. This allows the cards in your 'Maquetas Interactivas' section to adopt a uniform height based on the tallest card in the row, utilizing flexbox properties. The `flex-1` class on `CardContent` ensures that the content area expands to fill the available space within each card, while `h-full` on the `Card` component itself, combined with the parent flex row's default `align-items: stretch`, ensures all cards match in height.